### PR TITLE
Bug fixes: consistent name, and only copy data['dt'] if dt was defined

### DIFF
--- a/gsr.py
+++ b/gsr.py
@@ -448,7 +448,8 @@ class Snapshot:
             d['rho'] = self.data['rho']
             d['hsml'] = self.data['hsml']
 
-        d['dt'] = self.data['dt'][ptype]
+        if self.enable_timesteps:
+            d['dt'] = self.data['dt'][ptype]
 
         return d
 
@@ -475,10 +476,10 @@ class Snapshot:
                      '% .5e', '% .5e', '% .5e',
                      '% .5e', '% .5e', '% .5e']
 
-        assert(len(id) == len(mass) == len(pos) == len(vel))
-        assert(len(id) == len(u) == len(rho) == len(hsml))
+        assert(len(ids) == len(mass) == len(pos) == len(vel))
+        assert(len(ids) == len(u) == len(rho) == len(hsml))
 
-        data_to_print = np.c_[id, mass, pos, vel, u, rho, hsml]
+        data_to_print = np.c_[ids, mass, pos, vel, u, rho, hsml]
         np.savetxt(self.fname+'.asc', data_to_print, fmt = fmtstring)
 
     def print_data_by_type(self, ptype):


### PR DESCRIPTION
I believe I found some bugs which were making it impossible to run a couple of important functions in the `Snapshot` class, so this pull request includes the minor fixes needed to make the code work again.

One bug fix is in the function `to_ascii` which could not run because the name `id` or `ids` was not consistent.

The other is in the function `get_data_by_type` because the code was trying to copy `self.data['dt']` even though the `dt` was never defined (since `enable_timesteps` was false).

I hope to hear back from you soon!

Thanks,
Arthur